### PR TITLE
Fix async call for Python 3.12

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* Fix ASGI compatibility on Python 3.12.
+
+  Thanks to Alexandre Spaeth in `PR #426 <https://github.com/adamchainz/django-permissions-policy/pull/426>`__.
+
 4.18.0 (2023-10-09)
 -------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
+  "asgiref>=3.6",
   "Django>=3.2",
 ]
 urls = {Changelog = "https://github.com/adamchainz/django-permissions-policy/blob/main/CHANGELOG.rst",Funding = "https://adamj.eu/books/",Repository = "https://github.com/adamchainz/django-permissions-policy"}

--- a/src/django_permissions_policy/__init__.py
+++ b/src/django_permissions_policy/__init__.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-import asyncio
-import inspect
-from typing import Any
 from typing import Awaitable
 from typing import Callable
-from typing import TypeVar
 
+from asgiref.sync import iscoroutinefunction
+from asgiref.sync import markcoroutinefunction
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.signals import setting_changed
@@ -14,18 +12,6 @@ from django.dispatch import receiver
 from django.http import HttpRequest
 from django.http.response import HttpResponseBase
 from django.utils.functional import cached_property
-
-
-_F = TypeVar("_F", bound=Callable[..., Any])
-if hasattr(inspect, "markcoroutinefunction"):
-    iscoroutinefunction = inspect.iscoroutinefunction
-    markcoroutinefunction: Callable[[_F], _F] = inspect.markcoroutinefunction
-else:
-    iscoroutinefunction = asyncio.iscoroutinefunction  # type: ignore[assignment]
-
-    def markcoroutinefunction(func: _F) -> _F:
-        func._is_coroutine = asyncio.coroutines._is_coroutine  # type: ignore
-        return func
 
 
 _FEATURE_NAMES: set[str] = {

--- a/src/django_permissions_policy/__init__.py
+++ b/src/django_permissions_policy/__init__.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-import inspect
 import asyncio
-from typing import Any, Awaitable, TypeVar
+import inspect
+from typing import Any
+from typing import Awaitable
 from typing import Callable
+from typing import TypeVar
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured

--- a/src/django_permissions_policy/__init__.py
+++ b/src/django_permissions_policy/__init__.py
@@ -114,8 +114,9 @@ class PermissionsPolicyMiddleware:
         ),
     ) -> None:
         self.get_response = get_response
+        self.async_mode = iscoroutinefunction(self.get_response)
 
-        if iscoroutinefunction(self.get_response):
+        if self.async_mode:
             # Mark the class as async-capable, but do the actual switch
             # inside __call__ to avoid swapping out dunder methods
             markcoroutinefunction(self)
@@ -126,7 +127,7 @@ class PermissionsPolicyMiddleware:
     def __call__(
         self, request: HttpRequest
     ) -> HttpResponseBase | Awaitable[HttpResponseBase]:
-        if iscoroutinefunction(self):
+        if self.async_mode:
             return self.__acall__(request)
         response = self.get_response(request)
         assert isinstance(response, HttpResponseBase)  # type narrow

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -18,6 +18,7 @@ ALLOWED_HOSTS = ["*"]
 INSTALLED_APPS: list[str] = []
 
 MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
     "django_permissions_policy.PermissionsPolicyMiddleware",
     "django.middleware.common.CommonMiddleware",
 ]

--- a/tests/test_django_permissions_policy.py
+++ b/tests/test_django_permissions_policy.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from http import HTTPStatus
+
 import pytest
 from django.core.exceptions import ImproperlyConfigured
 from django.test import override_settings
@@ -13,7 +15,7 @@ class PermissionsPolicyMiddlewareTests(SimpleTestCase):
     def test_index(self):
         resp = self.client.get("/")
 
-        assert resp.status_code == 200
+        assert resp.status_code == HTTPStatus.OK
         assert resp.content == b"Hello World"
 
     def test_no_setting(self):
@@ -106,6 +108,7 @@ class PermissionsPolicyMiddlewareTests(SimpleTestCase):
 
     async def test_async(self):
         with override_settings(PERMISSIONS_POLICY={"geolocation": "self"}):
-            resp = await self.async_client.get("async/")
+            resp = await self.async_client.get("/async/")
 
+        assert resp.status_code == HTTPStatus.OK
         assert resp["Permissions-Policy"] == "geolocation=(self)"

--- a/tests/test_django_permissions_policy.py
+++ b/tests/test_django_permissions_policy.py
@@ -2,13 +2,9 @@ from __future__ import annotations
 
 import pytest
 from django.core.exceptions import ImproperlyConfigured
-from django.http import HttpResponse
-from django.http.response import HttpResponseBase
 from django.test import override_settings
 from django.test import RequestFactory
 from django.test import SimpleTestCase
-
-from django_permissions_policy import PermissionsPolicyMiddleware
 
 
 class PermissionsPolicyMiddlewareTests(SimpleTestCase):
@@ -109,15 +105,7 @@ class PermissionsPolicyMiddlewareTests(SimpleTestCase):
         assert resp["Permissions-Policy"] == "geolocation=(self)"
 
     async def test_async(self):
-        async def dummy_async_view(request):
-            return HttpResponse("Hello!")
-
-        middleware = PermissionsPolicyMiddleware(dummy_async_view)
-        request = self.request_factory.get("/", HTTP_HX_REQUEST="true")
-
         with override_settings(PERMISSIONS_POLICY={"geolocation": "self"}):
-            result = middleware(request)
-            assert not isinstance(result, HttpResponseBase)  # type narrow
-            response = await result
+            resp = await self.async_client.get("/")
 
-        assert response["Permissions-Policy"] == "geolocation=(self)"
+        assert resp["Permissions-Policy"] == "geolocation=(self)"

--- a/tests/test_django_permissions_policy.py
+++ b/tests/test_django_permissions_policy.py
@@ -106,6 +106,6 @@ class PermissionsPolicyMiddlewareTests(SimpleTestCase):
 
     async def test_async(self):
         with override_settings(PERMISSIONS_POLICY={"geolocation": "self"}):
-            resp = await self.async_client.get("/")
+            resp = await self.async_client.get("async/")
 
         assert resp["Permissions-Policy"] == "geolocation=(self)"

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from django.urls import path
 
-from tests.testapp.views import index
+from tests.testapp import views
 
-urlpatterns = [path("", index, name="index")]
+urlpatterns = [
+    path("", views.index),
+    path("async/", views.async_index),
+]

--- a/tests/testapp/views.py
+++ b/tests/testapp/views.py
@@ -5,3 +5,7 @@ from django.http import HttpResponse
 
 def index(request):
     return HttpResponse("Hello World")
+
+
+async def async_index(request):
+    return HttpResponse("Hello World")


### PR DESCRIPTION
This is my suggestion to fix #425. I used the same implementation as `asgiref`. 
`asgiref` being a Django dependency, maybe it would be even cleaner to just do `from asgiref.sync import iscoroutinefunction, markcoroutinefunction`? I’ll let you decide.

Also, I’ll try to add a proper test to it because I’m myself not 100% convinced why this is needed.